### PR TITLE
Fix an error on migration

### DIFF
--- a/database/migrations/0000_00_00_000000_create_shoppingcart_table.php
+++ b/database/migrations/0000_00_00_000000_create_shoppingcart_table.php
@@ -12,8 +12,8 @@ class CreateShoppingcartTable extends Migration
     public function up()
     {
         Schema::create(config('cart.database.table'), function (Blueprint $table) {
-            $table->string('identifier');
-            $table->string('instance');
+            $table->string('identifier', 125);
+            $table->string('instance', 125);
             $table->longText('content');
             $table->nullableTimestamps();
 


### PR DESCRIPTION
Currently in laravel 7, when trying to migrate, laravel throws the error: 

> PDOException::("SQLSTATE[42000]: Syntax error or access violation: 1071 Specified key was too long; max key length is 1000 bytes")

So to fix it, I limited the number of characters to 125, which is the maximum number that will not throw the error. The identifier is only 32 characters. So more than 125 characters is not needed anyway.